### PR TITLE
Add PrivateMessageEvent to listen to private messages

### DIFF
--- a/src/main/java/venture/Aust1n46/chat/api/events/PrivateMessageEvent.java
+++ b/src/main/java/venture/Aust1n46/chat/api/events/PrivateMessageEvent.java
@@ -1,0 +1,49 @@
+package venture.Aust1n46.chat.api.events;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import venture.Aust1n46.chat.model.VentureChatPlayer;
+
+/**
+ * Event called when a private message has been sent to a player.
+ * This event can not be cancelled.
+ *
+ * @author LOOHP
+ */
+@Getter
+public class PrivateMessageEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private final VentureChatPlayer sender;
+    private final VentureChatPlayer receiver;
+    private final String msg;
+    private @Setter String echo;
+    private @Setter String send;
+    private @Setter String spy;
+    private final boolean bungee;
+
+    public PrivateMessageEvent(VentureChatPlayer sender, VentureChatPlayer receiver, String msg, String echo, String send, String spy, boolean bungee) {
+        super(!Bukkit.isPrimaryThread());
+        this.sender = sender;
+        this.receiver = receiver;
+        this.msg = msg;
+        this.echo = echo;
+        this.send = send;
+        this.spy = spy;
+        this.bungee = bungee;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+}

--- a/src/main/java/venture/Aust1n46/chat/api/events/PrivateMessageEvent.java
+++ b/src/main/java/venture/Aust1n46/chat/api/events/PrivateMessageEvent.java
@@ -26,8 +26,8 @@ public class PrivateMessageEvent extends Event {
     private @Setter String spy;
     private final boolean bungee;
 
-    public PrivateMessageEvent(VentureChatPlayer sender, VentureChatPlayer receiver, String msg, String echo, String send, String spy, boolean bungee) {
-        super(!Bukkit.isPrimaryThread());
+    public PrivateMessageEvent(VentureChatPlayer sender, VentureChatPlayer receiver, String msg, String echo, String send, String spy, boolean bungee, boolean async) {
+        super(async);
         this.sender = sender;
         this.receiver = receiver;
         this.msg = msg;

--- a/src/main/java/venture/Aust1n46/chat/api/events/PrivateMessageEvent.java
+++ b/src/main/java/venture/Aust1n46/chat/api/events/PrivateMessageEvent.java
@@ -3,6 +3,7 @@ package venture.Aust1n46.chat.api.events;
 import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.Bukkit;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import venture.Aust1n46.chat.model.VentureChatPlayer;
@@ -14,13 +15,14 @@ import venture.Aust1n46.chat.model.VentureChatPlayer;
  * @author LOOHP
  */
 @Getter
-public class PrivateMessageEvent extends Event {
+public class PrivateMessageEvent extends Event implements Cancellable {
 
     private static final HandlerList handlers = new HandlerList();
 
     private final VentureChatPlayer sender;
     private final VentureChatPlayer receiver;
     private final String msg;
+    private @Getter @Setter boolean cancelled;
     private @Setter String echo;
     private @Setter String send;
     private @Setter String spy;
@@ -35,6 +37,7 @@ public class PrivateMessageEvent extends Event {
         this.send = send;
         this.spy = spy;
         this.bungee = bungee;
+        this.cancelled = false;
     }
 
     @Override
@@ -45,5 +48,4 @@ public class PrivateMessageEvent extends Event {
     public static HandlerList getHandlerList() {
         return handlers;
     }
-
 }

--- a/src/main/java/venture/Aust1n46/chat/api/events/PrivateMessageEvent.java
+++ b/src/main/java/venture/Aust1n46/chat/api/events/PrivateMessageEvent.java
@@ -2,7 +2,6 @@ package venture.Aust1n46.chat.api.events;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.bukkit.Bukkit;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;

--- a/src/main/java/venture/Aust1n46/chat/controllers/PluginMessageController.java
+++ b/src/main/java/venture/Aust1n46/chat/controllers/PluginMessageController.java
@@ -739,6 +739,9 @@ public class PluginMessageController {
 
 					PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(playerApiService.getOnlineMineverseChatPlayer(sender), p, msg, echo, send, spy, true, !plugin.getServer().isPrimaryThread());
 					plugin.getServer().getPluginManager().callEvent(privateMessageEvent);
+					if (privateMessageEvent.isCancelled()) {
+						return;
+					}
 					send = privateMessageEvent.getSend();
 					echo = privateMessageEvent.getEcho();
 					spy = privateMessageEvent.getSpy();

--- a/src/main/java/venture/Aust1n46/chat/controllers/PluginMessageController.java
+++ b/src/main/java/venture/Aust1n46/chat/controllers/PluginMessageController.java
@@ -737,8 +737,8 @@ public class PluginMessageController {
 					echo = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(p.getPlayer(), echo.replaceAll("receiver_", ""))) + msg;
 					spy = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(p.getPlayer(), spy.replaceAll("receiver_", ""))) + msg;
 
-					PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(playerApiService.getOnlineMineverseChatPlayer(sender), p, msg, echo, send, spy, true, !Bukkit.isPrimaryThread());
-					Bukkit.getPluginManager().callEvent(privateMessageEvent);
+					PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(playerApiService.getOnlineMineverseChatPlayer(sender), p, msg, echo, send, spy, true, !plugin.getServer().isPrimaryThread());
+					plugin.getServer().getPluginManager().callEvent(privateMessageEvent);
 					send = privateMessageEvent.getSend();
 					echo = privateMessageEvent.getEcho();
 					spy = privateMessageEvent.getSpy();

--- a/src/main/java/venture/Aust1n46/chat/controllers/PluginMessageController.java
+++ b/src/main/java/venture/Aust1n46/chat/controllers/PluginMessageController.java
@@ -737,7 +737,7 @@ public class PluginMessageController {
 					echo = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(p.getPlayer(), echo.replaceAll("receiver_", ""))) + msg;
 					spy = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(p.getPlayer(), spy.replaceAll("receiver_", ""))) + msg;
 
-					PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(playerApiService.getOnlineMineverseChatPlayer(sender), p, msg, echo, send, spy, true);
+					PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(playerApiService.getOnlineMineverseChatPlayer(sender), p, msg, echo, send, spy, true, !Bukkit.isPrimaryThread());
 					Bukkit.getPluginManager().callEvent(privateMessageEvent);
 					send = privateMessageEvent.getSend();
 					echo = privateMessageEvent.getEcho();

--- a/src/main/java/venture/Aust1n46/chat/controllers/PluginMessageController.java
+++ b/src/main/java/venture/Aust1n46/chat/controllers/PluginMessageController.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
@@ -19,6 +20,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import me.clip.placeholderapi.PlaceholderAPI;
+import venture.Aust1n46.chat.api.events.PrivateMessageEvent;
 import venture.Aust1n46.chat.api.events.VentureChatEvent;
 import venture.Aust1n46.chat.initators.commands.MuteContainer;
 import venture.Aust1n46.chat.initiators.application.VentureChat;
@@ -730,7 +732,18 @@ public class PluginMessageController {
 						sendPluginMessage(stream);
 						return;
 					}
-					p.getPlayer().sendMessage(FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(p.getPlayer(), send.replaceAll("receiver_", ""))) + msg);
+
+					send = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(p.getPlayer(), send.replaceAll("receiver_", ""))) + msg;
+					echo = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(p.getPlayer(), echo.replaceAll("receiver_", ""))) + msg;
+					spy = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(p.getPlayer(), spy.replaceAll("receiver_", ""))) + msg;
+
+					PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(playerApiService.getOnlineMineverseChatPlayer(sender), p, msg, echo, send, spy, true);
+					Bukkit.getPluginManager().callEvent(privateMessageEvent);
+					send = privateMessageEvent.getSend();
+					echo = privateMessageEvent.getEcho();
+					spy = privateMessageEvent.getSpy();
+					
+					p.getPlayer().sendMessage(send);
 					if (p.isNotifications()) {
 						formatService.playMessageSound(p);
 					}
@@ -747,8 +760,8 @@ public class PluginMessageController {
 					out.writeUTF(p.getUuid().toString());
 					out.writeUTF(sender.toString());
 					out.writeUTF(sName);
-					out.writeUTF(FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(p.getPlayer(), echo.replaceAll("receiver_", ""))) + msg);
-					out.writeUTF(FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(p.getPlayer(), spy.replaceAll("receiver_", ""))) + msg);
+					out.writeUTF(echo);
+					out.writeUTF(spy);
 					sendPluginMessage(stream);
 					return;
 				}

--- a/src/main/java/venture/Aust1n46/chat/initators/commands/Message.java
+++ b/src/main/java/venture/Aust1n46/chat/initators/commands/Message.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.util.StringUtil;
@@ -13,6 +14,7 @@ import org.bukkit.util.StringUtil;
 import com.google.inject.Inject;
 
 import me.clip.placeholderapi.PlaceholderAPI;
+import venture.Aust1n46.chat.api.events.PrivateMessageEvent;
 import venture.Aust1n46.chat.controllers.PluginMessageController;
 import venture.Aust1n46.chat.initiators.application.VentureChat;
 import venture.Aust1n46.chat.localization.LocalizedMessage;
@@ -103,6 +105,12 @@ public class Message extends PlayerCommand {
 				send = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), send.replaceAll("receiver_", ""))) + msg;
 				echo = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), echo.replaceAll("receiver_", ""))) + msg;
 				spy = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), spy.replaceAll("receiver_", ""))) + msg;
+
+				PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(mcp, player, msg, echo, send, spy, false);
+				Bukkit.getPluginManager().callEvent(privateMessageEvent);
+				send = privateMessageEvent.getSend();
+				echo = privateMessageEvent.getEcho();
+				spy = privateMessageEvent.getSpy();
 
 				player.setReplyPlayer(mcp.getUuid());
 				mcp.setReplyPlayer(player.getUuid());

--- a/src/main/java/venture/Aust1n46/chat/initators/commands/Message.java
+++ b/src/main/java/venture/Aust1n46/chat/initators/commands/Message.java
@@ -108,6 +108,9 @@ public class Message extends PlayerCommand {
 
 				PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(mcp, player, msg, echo, send, spy, false, !plugin.getServer().isPrimaryThread());
 				plugin.getServer().getPluginManager().callEvent(privateMessageEvent);
+				if (privateMessageEvent.isCancelled()) {
+					return;
+				}
 				send = privateMessageEvent.getSend();
 				echo = privateMessageEvent.getEcho();
 				spy = privateMessageEvent.getSpy();

--- a/src/main/java/venture/Aust1n46/chat/initators/commands/Message.java
+++ b/src/main/java/venture/Aust1n46/chat/initators/commands/Message.java
@@ -106,8 +106,8 @@ public class Message extends PlayerCommand {
 				echo = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), echo.replaceAll("receiver_", ""))) + msg;
 				spy = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), spy.replaceAll("receiver_", ""))) + msg;
 
-				PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(mcp, player, msg, echo, send, spy, false, !Bukkit.isPrimaryThread());
-				Bukkit.getPluginManager().callEvent(privateMessageEvent);
+				PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(mcp, player, msg, echo, send, spy, false, !plugin.getServer().isPrimaryThread());
+				plugin.getServer().getPluginManager().callEvent(privateMessageEvent);
 				send = privateMessageEvent.getSend();
 				echo = privateMessageEvent.getEcho();
 				spy = privateMessageEvent.getSpy();

--- a/src/main/java/venture/Aust1n46/chat/initators/commands/Message.java
+++ b/src/main/java/venture/Aust1n46/chat/initators/commands/Message.java
@@ -106,7 +106,7 @@ public class Message extends PlayerCommand {
 				echo = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), echo.replaceAll("receiver_", ""))) + msg;
 				spy = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), spy.replaceAll("receiver_", ""))) + msg;
 
-				PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(mcp, player, msg, echo, send, spy, false);
+				PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(mcp, player, msg, echo, send, spy, false, !Bukkit.isPrimaryThread());
 				Bukkit.getPluginManager().callEvent(privateMessageEvent);
 				send = privateMessageEvent.getSend();
 				echo = privateMessageEvent.getEcho();

--- a/src/main/java/venture/Aust1n46/chat/initators/commands/Reply.java
+++ b/src/main/java/venture/Aust1n46/chat/initators/commands/Reply.java
@@ -96,7 +96,7 @@ public class Reply extends PlayerCommand {
 					echo = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), echo.replaceAll("receiver_", ""))) + msg;
 					spy = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), spy.replaceAll("receiver_", ""))) + msg;
 
-					PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(mcp, player, msg, echo, send, spy, false);
+					PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(mcp, player, msg, echo, send, spy, false, !Bukkit.isPrimaryThread());
 					Bukkit.getPluginManager().callEvent(privateMessageEvent);
 					send = privateMessageEvent.getSend();
 					echo = privateMessageEvent.getEcho();

--- a/src/main/java/venture/Aust1n46/chat/initators/commands/Reply.java
+++ b/src/main/java/venture/Aust1n46/chat/initators/commands/Reply.java
@@ -3,11 +3,13 @@ package venture.Aust1n46.chat.initators.commands;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import com.google.inject.Inject;
 
 import me.clip.placeholderapi.PlaceholderAPI;
+import venture.Aust1n46.chat.api.events.PrivateMessageEvent;
 import venture.Aust1n46.chat.controllers.PluginMessageController;
 import venture.Aust1n46.chat.initiators.application.VentureChat;
 import venture.Aust1n46.chat.localization.LocalizedMessage;
@@ -93,6 +95,12 @@ public class Reply extends PlayerCommand {
 					send = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), send.replaceAll("receiver_", ""))) + msg;
 					echo = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), echo.replaceAll("receiver_", ""))) + msg;
 					spy = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), spy.replaceAll("receiver_", ""))) + msg;
+
+					PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(mcp, player, msg, echo, send, spy, false);
+					Bukkit.getPluginManager().callEvent(privateMessageEvent);
+					send = privateMessageEvent.getSend();
+					echo = privateMessageEvent.getEcho();
+					spy = privateMessageEvent.getSpy();
 
 					if (!mcp.getPlayer().hasPermission("venturechat.spy.override")) {
 						for (VentureChatPlayer p : playerApiService.getOnlineMineverseChatPlayers()) {

--- a/src/main/java/venture/Aust1n46/chat/initators/commands/Reply.java
+++ b/src/main/java/venture/Aust1n46/chat/initators/commands/Reply.java
@@ -96,8 +96,8 @@ public class Reply extends PlayerCommand {
 					echo = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), echo.replaceAll("receiver_", ""))) + msg;
 					spy = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), spy.replaceAll("receiver_", ""))) + msg;
 
-					PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(mcp, player, msg, echo, send, spy, false, !Bukkit.isPrimaryThread());
-					Bukkit.getPluginManager().callEvent(privateMessageEvent);
+					PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(mcp, player, msg, echo, send, spy, false, !plugin.getServer().isPrimaryThread());
+					plugin.getServer().getPluginManager().callEvent(privateMessageEvent);
 					send = privateMessageEvent.getSend();
 					echo = privateMessageEvent.getEcho();
 					spy = privateMessageEvent.getSpy();

--- a/src/main/java/venture/Aust1n46/chat/initators/commands/Reply.java
+++ b/src/main/java/venture/Aust1n46/chat/initators/commands/Reply.java
@@ -98,6 +98,9 @@ public class Reply extends PlayerCommand {
 
 					PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(mcp, player, msg, echo, send, spy, false, !plugin.getServer().isPrimaryThread());
 					plugin.getServer().getPluginManager().callEvent(privateMessageEvent);
+					if (privateMessageEvent.isCancelled()) {
+						return;
+					}
 					send = privateMessageEvent.getSend();
 					echo = privateMessageEvent.getEcho();
 					spy = privateMessageEvent.getSpy();

--- a/src/main/java/venture/Aust1n46/chat/initiators/listeners/ChatListener.java
+++ b/src/main/java/venture/Aust1n46/chat/initiators/listeners/ChatListener.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.util.Set;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -22,6 +23,7 @@ import com.palmergames.bukkit.towny.object.Resident;
 
 import me.clip.placeholderapi.PlaceholderAPI;
 import net.essentialsx.api.v2.services.discord.DiscordService;
+import venture.Aust1n46.chat.api.events.PrivateMessageEvent;
 import venture.Aust1n46.chat.api.events.VentureChatEvent;
 import venture.Aust1n46.chat.controllers.PluginMessageController;
 import venture.Aust1n46.chat.initators.commands.MuteContainer;
@@ -123,6 +125,12 @@ public class ChatListener implements Listener {
 			send = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(tp.getPlayer(), send.replaceAll("receiver_", ""))) + filtered;
 			echo = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(tp.getPlayer(), echo.replaceAll("receiver_", ""))) + filtered;
 			spy = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(tp.getPlayer(), spy.replaceAll("receiver_", ""))) + filtered;
+
+			PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(ventureChatPlayer, tp, filtered, echo, send, spy, false);
+			Bukkit.getPluginManager().callEvent(privateMessageEvent);
+			send = privateMessageEvent.getSend();
+			echo = privateMessageEvent.getEcho();
+			spy = privateMessageEvent.getSpy();
 
 			if (!ventureChatPlayer.getPlayer().hasPermission("venturechat.spy.override")) {
 				for (VentureChatPlayer p : playerApiService.getOnlineMineverseChatPlayers()) {

--- a/src/main/java/venture/Aust1n46/chat/initiators/listeners/ChatListener.java
+++ b/src/main/java/venture/Aust1n46/chat/initiators/listeners/ChatListener.java
@@ -128,6 +128,9 @@ public class ChatListener implements Listener {
 
 			PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(ventureChatPlayer, tp, filtered, echo, send, spy, false, !plugin.getServer().isPrimaryThread());
 			plugin.getServer().getPluginManager().callEvent(privateMessageEvent);
+			if (privateMessageEvent.isCancelled()) {
+				return;
+			}
 			send = privateMessageEvent.getSend();
 			echo = privateMessageEvent.getEcho();
 			spy = privateMessageEvent.getSpy();

--- a/src/main/java/venture/Aust1n46/chat/initiators/listeners/ChatListener.java
+++ b/src/main/java/venture/Aust1n46/chat/initiators/listeners/ChatListener.java
@@ -126,7 +126,7 @@ public class ChatListener implements Listener {
 			echo = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(tp.getPlayer(), echo.replaceAll("receiver_", ""))) + filtered;
 			spy = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(tp.getPlayer(), spy.replaceAll("receiver_", ""))) + filtered;
 
-			PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(ventureChatPlayer, tp, filtered, echo, send, spy, false);
+			PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(ventureChatPlayer, tp, filtered, echo, send, spy, false, !Bukkit.isPrimaryThread());
 			Bukkit.getPluginManager().callEvent(privateMessageEvent);
 			send = privateMessageEvent.getSend();
 			echo = privateMessageEvent.getEcho();

--- a/src/main/java/venture/Aust1n46/chat/initiators/listeners/ChatListener.java
+++ b/src/main/java/venture/Aust1n46/chat/initiators/listeners/ChatListener.java
@@ -126,8 +126,8 @@ public class ChatListener implements Listener {
 			echo = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(tp.getPlayer(), echo.replaceAll("receiver_", ""))) + filtered;
 			spy = FormatUtils.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(tp.getPlayer(), spy.replaceAll("receiver_", ""))) + filtered;
 
-			PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(ventureChatPlayer, tp, filtered, echo, send, spy, false, !Bukkit.isPrimaryThread());
-			Bukkit.getPluginManager().callEvent(privateMessageEvent);
+			PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(ventureChatPlayer, tp, filtered, echo, send, spy, false, !plugin.getServer().isPrimaryThread());
+			plugin.getServer().getPluginManager().callEvent(privateMessageEvent);
 			send = privateMessageEvent.getSend();
 			echo = privateMessageEvent.getEcho();
 			spy = privateMessageEvent.getSpy();


### PR DESCRIPTION
This PR adds an event to listen to private messages. It's basically the same as the earlier one but applied accordingly to 4.0.0 instead, with the usage of `@Getter` `@Setter` annotations instead, mirroring what VentureChatEvent does.