### PR TITLE
Added new permission and bypass for message toggle

### DIFF
--- a/src/main/java/venture/Aust1n46/chat/initators/commands/Message.java
+++ b/src/main/java/venture/Aust1n46/chat/initators/commands/Message.java
@@ -72,6 +72,10 @@ public class Message extends PlayerCommand {
 			mcp.getPlayer().sendMessage(LocalizedMessage.BLOCKING_MESSAGE.toString().replace("{player}", player.getName()));
 			return;
 		}
+		else if (sender.hasPermission("venturechat.messagetoggle.bypass") && !player.isMessageToggle()){
+			sendBungeeCordMessage(mcp, command, args);
+			return;
+		}
 
 		if (args.length >= 2) {
 			String msg = "";


### PR DESCRIPTION
This PR adds an extra permissions check on the sender. If the sender has the permission `venturechat.messagetoggle.bypass` , then they'll be able to bypass the message toggle feature if the receiver has it enabled and allow them to message the specified player. 