### PR TITLE
Don't add empty action

### DIFF
--- a/src/main/java/mineverse/Aust1n46/chat/utilities/Format.java
+++ b/src/main/java/mineverse/Aust1n46/chat/utilities/Format.java
@@ -130,8 +130,8 @@ public class Format {
 							PlaceholderAPI.setBracketPlaceholders(icp.getPlayer(), hover.substring(0, hover.length() - 1)));
 				}
 				temp += convertToJsonColors(lastCode + formattedPlaceholder,
-						",\"clickEvent\":{\"action\":\"" + action + "\",\"value\":\"" + text
-								+ "\"},\"hoverEvent\":{\"action\":\"show_text\",\"value\":{\"text\":\"\",\"extra\":["
+						(action.isEmpty() ? "" : ",\"clickEvent\":{\"action\":\"" + action + "\",\"value\":\"" + text + "\"}")
+								+ ",\"hoverEvent\":{\"action\":\"show_text\",\"value\":{\"text\":\"\",\"extra\":["
 								+ convertToJsonColors(hover) + "]}}")
 						+ ",";
 				lastCode = getLastCode(lastCode + formattedPlaceholder);


### PR DESCRIPTION
Adding empty action may cause exception on other things. We should ensure plugin compatibility, e.g Bungee-Chat API cannot parse the json, because there's no *empty* action.
Fixes https://github.com/Rothes/ProtocolStringReplacer/issues/31