### PR TITLE
Allow for nested placeholders

### DIFF
--- a/src/main/java/mineverse/Aust1n46/chat/MineverseChat.java
+++ b/src/main/java/mineverse/Aust1n46/chat/MineverseChat.java
@@ -998,7 +998,7 @@ public class MineverseChat extends JavaPlugin implements PluginMessageListener {
 						sendPluginMessage(stream);
 						return;
 					}
-					p.getPlayer().sendMessage(Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(p.getPlayer(), send.replaceAll("receiver_", ""))) + msg);
+					p.getPlayer().sendMessage(Format.FormatStringAll(PlaceholderAPI.setPlaceholders(p.getPlayer(), send.replaceAll("receiver_", ""))) + msg);
 					if(p.hasNotifications()) {
 						Format.playMessageSound(p);
 					}
@@ -1015,8 +1015,8 @@ public class MineverseChat extends JavaPlugin implements PluginMessageListener {
 					out.writeUTF(p.getUUID().toString());
 					out.writeUTF(sender.toString());
 					out.writeUTF(sName);
-					out.writeUTF(Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(p.getPlayer(), echo.replaceAll("receiver_", ""))) + msg);
-					out.writeUTF(Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(p.getPlayer(), spy.replaceAll("receiver_", ""))) + msg);
+					out.writeUTF(Format.FormatStringAll(PlaceholderAPI.setPlaceholders(p.getPlayer(), echo.replaceAll("receiver_", ""))) + msg);
+					out.writeUTF(Format.FormatStringAll(PlaceholderAPI.setPlaceholders(p.getPlayer(), spy.replaceAll("receiver_", ""))) + msg);
 					sendPluginMessage(stream);
 					return;
 				}

--- a/src/main/java/mineverse/Aust1n46/chat/command/chat/VentureChatGui.java
+++ b/src/main/java/mineverse/Aust1n46/chat/command/chat/VentureChatGui.java
@@ -115,7 +115,7 @@ public class VentureChatGui extends Command {
 				ItemMeta gMeta = gStack.getItemMeta();
 				String displayName = g.getText().replace("{player_name}", target.getName()).replace("{channel}", channel.getName()).replace("{hash}", hash + "");
 				if (target.isOnline()) {
-					displayName = PlaceholderAPI.setBracketPlaceholders(target.getPlayer(), displayName);
+					displayName = PlaceholderAPI.setPlaceholders(target.getPlayer(), displayName);
 				}
 				gMeta.setDisplayName(Format.FormatStringAll(displayName));
 				List<String> gLore = new ArrayList<String>();

--- a/src/main/java/mineverse/Aust1n46/chat/command/message/Message.java
+++ b/src/main/java/mineverse/Aust1n46/chat/command/message/Message.java
@@ -83,13 +83,13 @@ public class Message extends Command {
 					msg = Format.FormatString(msg);
 				}
 
-				send = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatfrom").replaceAll("sender_", "")));
-				echo = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatto").replaceAll("sender_", "")));
-				spy = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatspy").replaceAll("sender_", "")));
+				send = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatfrom").replaceAll("sender_", "")));
+				echo = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatto").replaceAll("sender_", "")));
+				spy = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatspy").replaceAll("sender_", "")));
 
-				send = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), send.replaceAll("receiver_", ""))) + msg;
-				echo = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), echo.replaceAll("receiver_", ""))) + msg;
-				spy = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), spy.replaceAll("receiver_", ""))) + msg;
+				send = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(player.getPlayer(), send.replaceAll("receiver_", ""))) + msg;
+				echo = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(player.getPlayer(), echo.replaceAll("receiver_", ""))) + msg;
+				spy = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(player.getPlayer(), spy.replaceAll("receiver_", ""))) + msg;
 
 				player.setReplyPlayer(mcp.getUUID());
 				mcp.setReplyPlayer(player.getUUID());
@@ -182,11 +182,11 @@ public class Message extends Command {
 			msg = Format.FormatString(msg);
 		}
 
-		String send = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatfrom").replaceAll("sender_", "")));
-		String echo = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatto").replaceAll("sender_", "")));
+		String send = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatfrom").replaceAll("sender_", "")));
+		String echo = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatto").replaceAll("sender_", "")));
 		String spy = "VentureChat:NoSpy";
 		if (!mcp.getPlayer().hasPermission("venturechat.spy.override")) {
-			spy = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatspy").replaceAll("sender_", "")));
+			spy = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatspy").replaceAll("sender_", "")));
 		}
 		try {
 			out.writeUTF("Message");

--- a/src/main/java/mineverse/Aust1n46/chat/command/message/Reply.java
+++ b/src/main/java/mineverse/Aust1n46/chat/command/message/Reply.java
@@ -73,13 +73,13 @@ public class Reply extends Command {
 					}
 
 					send = Format
-							.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("replyformatfrom").replaceAll("sender_", "")));
-					echo = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("replyformatto").replaceAll("sender_", "")));
-					spy = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("replyformatspy").replaceAll("sender_", "")));
+							.FormatStringAll(PlaceholderAPI.setPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("replyformatfrom").replaceAll("sender_", "")));
+					echo = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("replyformatto").replaceAll("sender_", "")));
+					spy = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("replyformatspy").replaceAll("sender_", "")));
 
-					send = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), send.replaceAll("receiver_", ""))) + msg;
-					echo = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), echo.replaceAll("receiver_", ""))) + msg;
-					spy = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(player.getPlayer(), spy.replaceAll("receiver_", ""))) + msg;
+					send = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(player.getPlayer(), send.replaceAll("receiver_", ""))) + msg;
+					echo = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(player.getPlayer(), echo.replaceAll("receiver_", ""))) + msg;
+					spy = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(player.getPlayer(), spy.replaceAll("receiver_", ""))) + msg;
 
 					if (!mcp.getPlayer().hasPermission("venturechat.spy.override")) {
 						for (MineverseChatPlayer p : MineverseChatAPI.getOnlineMineverseChatPlayers()) {
@@ -128,11 +128,11 @@ public class Reply extends Command {
 			msg = Format.FormatString(msg);
 		}
 
-		String send = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("replyformatfrom").replaceAll("sender_", "")));
-		String echo = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("replyformatto").replaceAll("sender_", "")));
+		String send = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("replyformatfrom").replaceAll("sender_", "")));
+		String echo = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("replyformatto").replaceAll("sender_", "")));
 		String spy = "VentureChat:NoSpy";
 		if (!mcp.getPlayer().hasPermission("venturechat.spy.override")) {
-			spy = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("replyformatspy").replaceAll("sender_", "")));
+			spy = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("replyformatspy").replaceAll("sender_", "")));
 		}
 		try {
 			out.writeUTF("Message");

--- a/src/main/java/mineverse/Aust1n46/chat/listeners/ChatListener.java
+++ b/src/main/java/mineverse/Aust1n46/chat/listeners/ChatListener.java
@@ -123,13 +123,13 @@ public class ChatListener implements Listener {
 				}
 				filtered = " " + filtered;
 				
-				send = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatfrom").replaceAll("sender_", "")));
-				echo = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatto").replaceAll("sender_", "")));
-				spy = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatspy").replaceAll("sender_", "")));
+				send = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatfrom").replaceAll("sender_", "")));
+				echo = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatto").replaceAll("sender_", "")));
+				spy = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatspy").replaceAll("sender_", "")));
 				
-				send = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(tp.getPlayer(), send.replaceAll("receiver_", ""))) + filtered;
-				echo = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(tp.getPlayer(), echo.replaceAll("receiver_", ""))) + filtered;
-				spy = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(tp.getPlayer(), spy.replaceAll("receiver_", ""))) + filtered;
+				send = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(tp.getPlayer(), send.replaceAll("receiver_", ""))) + filtered;
+				echo = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(tp.getPlayer(), echo.replaceAll("receiver_", ""))) + filtered;
+				spy = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(tp.getPlayer(), spy.replaceAll("receiver_", ""))) + filtered;
 				
 				if(!mcp.getPlayer().hasPermission("venturechat.spy.override")) {
 					for(MineverseChatPlayer p : MineverseChatAPI.getOnlineMineverseChatPlayers()) {
@@ -478,14 +478,14 @@ public class ChatListener implements Listener {
 		}
 		if(curColor.equalsIgnoreCase("None")) {
 			// Format the placeholders and their color codes to determine the last color code to use for the chat message color
-			chat = Format.getLastCode(Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), format))) + chat;
+			chat = Format.getLastCode(Format.FormatStringAll(PlaceholderAPI.setPlaceholders(mcp.getPlayer(), format))) + chat;
 		}
 		else {
 			chat = curColor + chat;
 		}
 		
 		String globalJSON = Format.convertToJson(mcp, format, chat); 
-		format = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), Format.FormatStringAll(format)));
+		format = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(mcp.getPlayer(), Format.FormatStringAll(format)));
 		String message = Format.stripColor(format + chat); // UTF-8 encoding issues.
 		int hash = message.hashCode();
 		

--- a/src/main/java/mineverse/Aust1n46/chat/listeners/CommandListener.java
+++ b/src/main/java/mineverse/Aust1n46/chat/listeners/CommandListener.java
@@ -165,7 +165,7 @@ public class CommandListener implements Listener {
 				if (target != null) {
 					command = command.replace("{player_name}", target.getName());
 					if (target.isOnline()) {
-						command = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(target.getPlayer(), command));
+						command = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(target.getPlayer(), command));
 					}
 				} else {
 					command = command.replace("{player_name}", "Discord_Message");

--- a/src/main/java/mineverse/Aust1n46/chat/utilities/Format.java
+++ b/src/main/java/mineverse/Aust1n46/chat/utilities/Format.java
@@ -119,7 +119,7 @@ public class Format {
 					if (placeholder.contains(jsonAttribute.getName().replace("%", "").replace("%", ""))) {
 						action = jsonAttribute.getClickAction();
 						text = Format.FormatStringAll(
-								PlaceholderAPI.setBracketPlaceholders(icp.getPlayer(), jsonAttribute.getClickText()));
+								PlaceholderAPI.setPlaceholders(icp.getPlayer(), jsonAttribute.getClickText()));
 						for (String st : jsonAttribute.getHoverText()) {
 							hover += Format.FormatStringAll(st) + "\n";
 						}
@@ -127,7 +127,7 @@ public class Format {
 				}
 				if(!hover.isEmpty()) {
 					hover = Format.FormatStringAll(
-							PlaceholderAPI.setBracketPlaceholders(icp.getPlayer(), hover.substring(0, hover.length() - 1)));
+							PlaceholderAPI.setPlaceholders(icp.getPlayer(), hover.substring(0, hover.length() - 1)));
 				}
 				temp += convertToJsonColors(lastCode + formattedPlaceholder,
 						",\"clickEvent\":{\"action\":\"" + action + "\",\"value\":\"" + text

--- a/src/main/java/mineverse/Aust1n46/chat/utilities/Format.java
+++ b/src/main/java/mineverse/Aust1n46/chat/utilities/Format.java
@@ -45,7 +45,7 @@ public class Format {
 	private static final Pattern LEGACY_CHAT_COLOR_PATTERN = Pattern.compile(
 			"(?<!(&x(&[a-fA-F0-9]){5}))(?<!(&x(&[a-fA-F0-9]){4}))(?<!(&x(&[a-fA-F0-9]){3}))(?<!(&x(&[a-fA-F0-9]){2}))(?<!(&x(&[a-fA-F0-9]){1}))(?<!(&x))(&)([0-9a-fA-F])");
 	
-	private static final Pattern PLACEHOLDERAPI_PLACEHOLDER_PATTERN = Pattern.compile("\\{([^\\{\\}]+)\\}");
+	private static final Pattern PLACEHOLDERAPI_PLACEHOLDER_PATTERN = Pattern.compile("\\%[^\\{\\}%]*\\{?[^\\{\\}%]+\\}?[^\\{\\}%]*\\%");
 	
 	public static final long MILLISECONDS_PER_DAY = 86400000;
 	public static final long MILLISECONDS_PER_HOUR = 3600000;
@@ -109,14 +109,14 @@ public class Format {
 				indexStart = matcher.start();
 				indexEnd = matcher.end();
 				placeholder = remaining.substring(indexStart, indexEnd);
-				formattedPlaceholder = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(icp.getPlayer(), placeholder));
+				formattedPlaceholder = Format.FormatStringAll(PlaceholderAPI.setPlaceholders(icp.getPlayer(), placeholder));
 				temp += convertToJsonColors(lastCode + remaining.substring(0, indexStart)) + ",";
 				lastCode = getLastCode(lastCode + remaining.substring(0, indexStart));
 				String action = "";
 				String text = "";
 				String hover = "";
 				for (JsonAttribute jsonAttribute : format.getJsonAttributes()) {
-					if (placeholder.contains(jsonAttribute.getName().replace("{", "").replace("}", ""))) {
+					if (placeholder.contains(jsonAttribute.getName().replace("%", "").replace("%", ""))) {
 						action = jsonAttribute.getClickAction();
 						text = Format.FormatStringAll(
 								PlaceholderAPI.setBracketPlaceholders(icp.getPlayer(), jsonAttribute.getClickText()));


### PR DESCRIPTION
This change makes the formatting for VentureChat be able to parse nested placeholders.

tested formatting:
`%venturechat_channel_prefix%%changeoutput_equals_input:{marriage_is_married}_matcher:yes_ifmatch:&7[&4❤&7] &r_else:%%marriage_gender_chat_prefix%%uclans_tag_formated%%vault_prefix%%essentials_nickname%%vault_suffix%&e:`

the nested one:
`%changeoutput_equals_input:{marriage_is_married}_matcher:yes_ifmatch:&7[&4❤&7] &r_else:%`

This changes every formatting that is done with placeholderAPI to use %.