### PR TITLE
Support 1.19.1

### DIFF
--- a/src/main/java/mineverse/Aust1n46/chat/utilities/Format.java
+++ b/src/main/java/mineverse/Aust1n46/chat/utilities/Format.java
@@ -430,7 +430,11 @@ public class Format {
 
 	public static PacketContainer createPacketPlayOutChat(String json) {
 		final PacketContainer container;
-		if (VersionHandler.isUnder_1_19()) {
+		if (VersionHandler.isAbove_1_19()) {
+			container = new PacketContainer(PacketType.Play.Server.SYSTEM_CHAT);
+			container.getStrings().write(0, json);
+			container.getBooleans().write(0, false);
+		} else if (VersionHandler.isUnder_1_19()) {
 			WrappedChatComponent component = WrappedChatComponent.fromJson(json);
 			container = new PacketContainer(PacketType.Play.Server.CHAT);
 			container.getModifier().writeDefaults();
@@ -445,7 +449,11 @@ public class Format {
 
 	public static PacketContainer createPacketPlayOutChat(WrappedChatComponent component) {
 		final PacketContainer container;
-		if (VersionHandler.isUnder_1_19()) {
+		if (VersionHandler.isAbove_1_19()) {
+			container = new PacketContainer(PacketType.Play.Server.SYSTEM_CHAT);
+			container.getStrings().write(0, component.getJson());
+			container.getBooleans().write(0, false);
+		} else if (VersionHandler.isUnder_1_19()) {
 			container = new PacketContainer(PacketType.Play.Server.CHAT);
 			container.getModifier().writeDefaults();
 			container.getChatComponents().write(0, component);

--- a/src/main/java/mineverse/Aust1n46/chat/versions/VersionHandler.java
+++ b/src/main/java/mineverse/Aust1n46/chat/versions/VersionHandler.java
@@ -1,67 +1,76 @@
 package mineverse.Aust1n46.chat.versions;
 
-import org.bukkit.Bukkit;
+import com.comphenix.protocol.utility.MinecraftVersion;
 
 //This class contains methods for determining what version of Minecraft the server is running.
-public class VersionHandler {
+public final class VersionHandler {
+
+	public static final MinecraftVersion SERVER_VERSION = MinecraftVersion.getCurrentVersion();
+
+	private VersionHandler() {
+	}
 
 	public static boolean is1_7() {
-		return Bukkit.getVersion().contains("1.7");
+		return SERVER_VERSION.getMinor() == 7 && SERVER_VERSION.getMajor() == 1;
 	}
-	
+
 	public static boolean is1_8() {
-		return Bukkit.getVersion().contains("1.8");
+		return SERVER_VERSION.getMinor() == 8 && SERVER_VERSION.getMajor() == 1;
 	}
-	
+
 	public static boolean is1_9() {
-		return Bukkit.getVersion().contains("1.9");
+		return SERVER_VERSION.getMinor() == 9 && SERVER_VERSION.getMajor() == 1;
 	}
-	
+
 	public static boolean is1_10() {
-		return Bukkit.getVersion().contains("1.10");
+		return SERVER_VERSION.getMinor() == 10 && SERVER_VERSION.getMajor() == 1;
 	}
-	
+
 	public static boolean is1_11() {
-		return Bukkit.getVersion().contains("1.11");
+		return SERVER_VERSION.getMinor() == 11 && SERVER_VERSION.getMajor() == 1;
 	}
-	
+
 	public static boolean is1_12() {
-		return Bukkit.getVersion().contains("1.12");
+		return SERVER_VERSION.getMinor() == 12 && SERVER_VERSION.getMajor() == 1;
 	}
-	
+
 	public static boolean is1_13() {
-		return Bukkit.getVersion().contains("1.13");
+		return SERVER_VERSION.getMinor() == 13 && SERVER_VERSION.getMajor() == 1;
 	}
-	
+
 	public static boolean is1_14() {
-		return Bukkit.getVersion().contains("1.14");
+		return SERVER_VERSION.getBuild() != 4 && SERVER_VERSION.getMinor() == 14 && SERVER_VERSION.getMajor() == 1;
 	}
-	
+
 	public static boolean is1_14_4() {
-		return Bukkit.getVersion().contains("1.14.4");
+		return SERVER_VERSION.getBuild() == 4 && SERVER_VERSION.getMinor() == 14 && SERVER_VERSION.getMajor() == 1;
 	}
-	
+
 	public static boolean is1_15() {
-		return Bukkit.getVersion().contains("1.15");
+		return SERVER_VERSION.getMinor() == 15 && SERVER_VERSION.getMajor() == 1;
 	}
-	
+
 	public static boolean is1_16() {
-		return Bukkit.getVersion().contains("1.16");
+		return SERVER_VERSION.getMinor() == 16 && SERVER_VERSION.getMajor() == 1;
 	}
-	
+
 	public static boolean is1_17() {
-		return Bukkit.getVersion().contains("1.17");
+		return SERVER_VERSION.getMinor() == 17 && SERVER_VERSION.getMajor() == 1;
 	}
-	
+
 	public static boolean is1_18() {
-		return Bukkit.getVersion().contains("1.18");
+		return SERVER_VERSION.getMinor() == 18 && SERVER_VERSION.getMajor() == 1;
 	}
-	
+
 	public static boolean is1_19() {
-		return Bukkit.getVersion().contains("1.19");
+		return SERVER_VERSION.getBuild() == 0 && SERVER_VERSION.getMinor() == 19 && SERVER_VERSION.getMajor() == 1;
 	}
-	
+
 	public static boolean isUnder_1_19() {
-		return is1_7() || is1_8() || is1_9() || is1_10() || is1_11() || is1_12() || is1_13() || is1_14() || is1_15() || is1_16() || is1_17() || is1_18();
+		return !SERVER_VERSION.isAtLeast(MinecraftVersion.WILD_UPDATE);
+	}
+
+	public static boolean isAbove_1_19() {
+		return !is1_19() && SERVER_VERSION.isAtLeast(MinecraftVersion.WILD_UPDATE);
 	}
 }


### PR DESCRIPTION
First, refactor VersionHandler. ProtocolLib, which is already a hard dependency of this project, has a MinecraftVersion type that handles parsing the Bukkit version string. Using that allows us to more concisely determine the server version. Minecraft versions 1.19 and 1.19.1 have different protocols, so we don't want VersionHandler::is1_19 to be true for 1.19.1.

Then, fix the System Chat Packet which changed in format between 1.19 and 1.19.1.