### PR TITLE
Adds an event for private messaging

### DIFF
--- a/src/main/java/mineverse/Aust1n46/chat/MineverseChat.java
+++ b/src/main/java/mineverse/Aust1n46/chat/MineverseChat.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import mineverse.Aust1n46.chat.api.events.PrivateMessageEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -998,6 +999,22 @@ public class MineverseChat extends JavaPlugin implements PluginMessageListener {
 						sendPluginMessage(stream);
 						return;
 					}
+
+					PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(MineverseChatAPI.getMineverseChatPlayer(sender), p, msg, false);
+					getServer().getPluginManager().callEvent(privateMessageEvent);
+					if (privateMessageEvent.isCancelled()) {
+						out.writeUTF("Message");
+						out.writeUTF("CustomError");
+						System.out.println("Error: "+privateMessageEvent.getErrorMessage());
+						out.writeUTF(privateMessageEvent.getErrorMessage() == null ? "" : privateMessageEvent.getErrorMessage());
+						out.writeUTF(server);
+						out.writeUTF(receiver);
+						out.writeUTF(sender.toString());
+						sendPluginMessage(stream);
+						return;
+					}
+					msg = privateMessageEvent.getChat();
+
 					p.getPlayer().sendMessage(Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(p.getPlayer(), send.replaceAll("receiver_", ""))) + msg);
 					if(p.hasNotifications()) {
 						Format.playMessageSound(p);
@@ -1041,6 +1058,14 @@ public class MineverseChat extends JavaPlugin implements PluginMessageListener {
 					MineverseChatPlayer p = MineverseChatAPI.getOnlineMineverseChatPlayer(sender);
 					p.getPlayer().sendMessage(LocalizedMessage.BLOCKING_MESSAGE.toString()
 							.replace("{player}", receiver));
+				}
+				if(identifier.equals("CustomError")) {
+					String message = msgin.readUTF();
+					String receiver = msgin.readUTF();
+					UUID sender = UUID.fromString(msgin.readUTF());
+					MineverseChatPlayer p = MineverseChatAPI.getOnlineMineverseChatPlayer(sender);
+					p.getPlayer().sendMessage(message.replace("{player}", receiver));
+					System.out.println(message);
 				}
 				if(identifier.equals("Echo")) {
 					String receiverName = msgin.readUTF();

--- a/src/main/java/mineverse/Aust1n46/chat/MineverseChat.java
+++ b/src/main/java/mineverse/Aust1n46/chat/MineverseChat.java
@@ -1064,8 +1064,9 @@ public class MineverseChat extends JavaPlugin implements PluginMessageListener {
 					String receiver = msgin.readUTF();
 					UUID sender = UUID.fromString(msgin.readUTF());
 					MineverseChatPlayer p = MineverseChatAPI.getOnlineMineverseChatPlayer(sender);
-					p.getPlayer().sendMessage(message.replace("{player}", receiver));
-					System.out.println(message);
+					if(message.length()>0) {
+						p.getPlayer().sendMessage(message.replace("{player}", receiver));
+					}
 				}
 				if(identifier.equals("Echo")) {
 					String receiverName = msgin.readUTF();

--- a/src/main/java/mineverse/Aust1n46/chat/api/events/PrivateMessageEvent.java
+++ b/src/main/java/mineverse/Aust1n46/chat/api/events/PrivateMessageEvent.java
@@ -1,0 +1,75 @@
+package mineverse.Aust1n46.chat.api.events;
+
+import mineverse.Aust1n46.chat.MineverseChat;
+import mineverse.Aust1n46.chat.api.MineverseChatPlayer;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Event called when a message has been sent to a channel.
+ * This event can not be cancelled.
+ *
+ * @author Aust1n46
+ */
+public class PrivateMessageEvent extends Event implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+
+
+    private final MineverseChatPlayer from;
+    private final MineverseChatPlayer to;
+    private String chat;
+    private boolean cancelled;
+    private String errorMessage;
+
+    public PrivateMessageEvent(MineverseChatPlayer from, MineverseChatPlayer to, String chat) {
+        super(MineverseChat.ASYNC);
+        this.from = from;
+        this.to = to;
+        this.chat = chat;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public MineverseChatPlayer getFrom() {
+        return from;
+    }
+
+    public MineverseChatPlayer getTo() {
+        return to;
+    }
+
+    public String getChat() {
+        return this.chat;
+    }
+
+    public void setChat(String chat) {
+        this.chat = chat;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return handlers;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        cancelled = cancel;
+    }
+}

--- a/src/main/java/mineverse/Aust1n46/chat/api/events/PrivateMessageEvent.java
+++ b/src/main/java/mineverse/Aust1n46/chat/api/events/PrivateMessageEvent.java
@@ -1,6 +1,5 @@
 package mineverse.Aust1n46.chat.api.events;
 
-import mineverse.Aust1n46.chat.MineverseChat;
 import mineverse.Aust1n46.chat.api.MineverseChatPlayer;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -43,7 +42,6 @@ public class PrivateMessageEvent extends Event implements Cancellable {
     }
 
     /**
-     *
      * @return The error message set by a cancelling plugin, if any
      */
     public String getErrorMessage() {
@@ -52,6 +50,7 @@ public class PrivateMessageEvent extends Event implements Cancellable {
 
     /**
      * Sets a message to be shown to the sender if cancelled
+     *
      * @param errorMessage The message to be sent
      */
     public void setErrorMessage(String errorMessage) {
@@ -67,7 +66,7 @@ public class PrivateMessageEvent extends Event implements Cancellable {
     }
 
     public String getChat() {
-        return this.chat;
+        return " " + this.chat.trim();
     }
 
     public void setChat(String chat) {

--- a/src/main/java/mineverse/Aust1n46/chat/api/events/PrivateMessageEvent.java
+++ b/src/main/java/mineverse/Aust1n46/chat/api/events/PrivateMessageEvent.java
@@ -8,10 +8,9 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Event called when a message has been sent to a channel.
- * This event can not be cancelled.
+ * Event called when a private message has been sent.
  *
- * @author Aust1n46
+ * @author Heliosares
  */
 public class PrivateMessageEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
@@ -19,25 +18,42 @@ public class PrivateMessageEvent extends Event implements Cancellable {
 
     private final MineverseChatPlayer from;
     private final MineverseChatPlayer to;
+    private final boolean isLocal;
     private String chat;
     private boolean cancelled;
     private String errorMessage;
 
-    public PrivateMessageEvent(MineverseChatPlayer from, MineverseChatPlayer to, String chat) {
-        super(MineverseChat.ASYNC);
+    public PrivateMessageEvent(MineverseChatPlayer from, MineverseChatPlayer to, String chat, boolean local) {
+        super(false);
         this.from = from;
         this.to = to;
         this.chat = chat;
+        this.isLocal = local;
     }
 
     public static HandlerList getHandlerList() {
         return handlers;
     }
 
+    /**
+     * @return true if the message was sent from this server, otherwise false
+     */
+    public boolean isLocal() {
+        return isLocal;
+    }
+
+    /**
+     *
+     * @return The error message set by a cancelling plugin, if any
+     */
     public String getErrorMessage() {
         return errorMessage;
     }
 
+    /**
+     * Sets a message to be shown to the sender if cancelled
+     * @param errorMessage The message to be sent
+     */
     public void setErrorMessage(String errorMessage) {
         this.errorMessage = errorMessage;
     }

--- a/src/main/java/mineverse/Aust1n46/chat/command/message/Message.java
+++ b/src/main/java/mineverse/Aust1n46/chat/command/message/Message.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import mineverse.Aust1n46.chat.api.events.PrivateMessageEvent;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -82,6 +83,14 @@ public class Message extends Command {
 				if (mcp.getPlayer().hasPermission("venturechat.format")) {
 					msg = Format.FormatString(msg);
 				}
+
+                PrivateMessageEvent e = new PrivateMessageEvent(mcp, player, msg);
+                plugin.getServer().getPluginManager().callEvent(e);
+                if (e.isCancelled()) {
+                    if (e.getErrorMessage() != null) sender.sendMessage(e.getErrorMessage());
+                    return true;
+                }
+                msg = e.getChat();
 
 				send = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatfrom").replaceAll("sender_", "")));
 				echo = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatto").replaceAll("sender_", "")));

--- a/src/main/java/mineverse/Aust1n46/chat/command/message/Message.java
+++ b/src/main/java/mineverse/Aust1n46/chat/command/message/Message.java
@@ -84,13 +84,13 @@ public class Message extends Command {
 					msg = Format.FormatString(msg);
 				}
 
-                PrivateMessageEvent e = new PrivateMessageEvent(mcp, player, msg);
-                plugin.getServer().getPluginManager().callEvent(e);
-                if (e.isCancelled()) {
-                    if (e.getErrorMessage() != null) sender.sendMessage(e.getErrorMessage());
+                PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(mcp, player, msg, true);
+                plugin.getServer().getPluginManager().callEvent(privateMessageEvent);
+                if (privateMessageEvent.isCancelled()) {
+                    if (privateMessageEvent.getErrorMessage() != null) sender.sendMessage(privateMessageEvent.getErrorMessage());
                     return true;
                 }
-                msg = e.getChat();
+                msg = privateMessageEvent.getChat();
 
 				send = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatfrom").replaceAll("sender_", "")));
 				echo = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatto").replaceAll("sender_", "")));

--- a/src/main/java/mineverse/Aust1n46/chat/command/message/Reply.java
+++ b/src/main/java/mineverse/Aust1n46/chat/command/message/Reply.java
@@ -3,6 +3,7 @@ package mineverse.Aust1n46.chat.command.message;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 
+import mineverse.Aust1n46.chat.api.events.PrivateMessageEvent;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -71,6 +72,14 @@ public class Reply extends Command {
 					if (mcp.getPlayer().hasPermission("venturechat.format")) {
 						msg = Format.FormatString(msg);
 					}
+
+					PrivateMessageEvent e = new PrivateMessageEvent(mcp, player, msg);
+					plugin.getServer().getPluginManager().callEvent(e);
+					if (e.isCancelled()) {
+						if (e.getErrorMessage() != null) sender.sendMessage(e.getErrorMessage());
+						return true;
+					}
+					msg = e.getChat();
 
 					send = Format
 							.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("replyformatfrom").replaceAll("sender_", "")));

--- a/src/main/java/mineverse/Aust1n46/chat/command/message/Reply.java
+++ b/src/main/java/mineverse/Aust1n46/chat/command/message/Reply.java
@@ -73,13 +73,13 @@ public class Reply extends Command {
 						msg = Format.FormatString(msg);
 					}
 
-					PrivateMessageEvent e = new PrivateMessageEvent(mcp, player, msg);
-					plugin.getServer().getPluginManager().callEvent(e);
-					if (e.isCancelled()) {
-						if (e.getErrorMessage() != null) sender.sendMessage(e.getErrorMessage());
+					PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(mcp, player, msg, true);
+					plugin.getServer().getPluginManager().callEvent(privateMessageEvent);
+					if (privateMessageEvent.isCancelled()) {
+						if (privateMessageEvent.getErrorMessage() != null) sender.sendMessage(privateMessageEvent.getErrorMessage());
 						return true;
 					}
-					msg = e.getChat();
+					msg = privateMessageEvent.getChat();
 
 					send = Format
 							.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("replyformatfrom").replaceAll("sender_", "")));

--- a/src/main/java/mineverse/Aust1n46/chat/listeners/ChatListener.java
+++ b/src/main/java/mineverse/Aust1n46/chat/listeners/ChatListener.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.util.Set;
 
+import mineverse.Aust1n46.chat.api.events.PrivateMessageEvent;
 import net.essentialsx.api.v2.services.discord.DiscordService;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -122,6 +123,14 @@ public class ChatListener implements Listener {
 					filtered = Format.FormatString(filtered);
 				}
 				filtered = " " + filtered;
+
+				PrivateMessageEvent e = new PrivateMessageEvent(mcp, tp, filtered);
+				plugin.getServer().getPluginManager().callEvent(e);
+				if (e.isCancelled()) {
+					if (e.getErrorMessage() != null) mcp.getPlayer().sendMessage(e.getErrorMessage());
+					return;
+				}
+				filtered = e.getChat();
 				
 				send = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatfrom").replaceAll("sender_", "")));
 				echo = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatto").replaceAll("sender_", "")));

--- a/src/main/java/mineverse/Aust1n46/chat/listeners/ChatListener.java
+++ b/src/main/java/mineverse/Aust1n46/chat/listeners/ChatListener.java
@@ -124,13 +124,13 @@ public class ChatListener implements Listener {
 				}
 				filtered = " " + filtered;
 
-				PrivateMessageEvent e = new PrivateMessageEvent(mcp, tp, filtered);
-				plugin.getServer().getPluginManager().callEvent(e);
-				if (e.isCancelled()) {
-					if (e.getErrorMessage() != null) mcp.getPlayer().sendMessage(e.getErrorMessage());
+				PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(mcp, tp, filtered, true);
+				plugin.getServer().getPluginManager().callEvent(privateMessageEvent);
+				if (privateMessageEvent.isCancelled()) {
+					if (privateMessageEvent.getErrorMessage() != null) mcp.getPlayer().sendMessage(privateMessageEvent.getErrorMessage());
 					return;
 				}
-				filtered = e.getChat();
+				filtered = privateMessageEvent.getChat();
 				
 				send = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatfrom").replaceAll("sender_", "")));
 				echo = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatto").replaceAll("sender_", "")));

--- a/src/main/java/mineverse/Aust1n46/chat/proxy/VentureChatProxy.java
+++ b/src/main/java/mineverse/Aust1n46/chat/proxy/VentureChatProxy.java
@@ -448,6 +448,20 @@ public class VentureChatProxy {
 						source.sendPluginMessage(server, outstream.toByteArray());
 					}
 				}
+				if(identifier.equals("CustomError")) {
+					String message = in.readUTF();
+					String server = in.readUTF();
+					String player = in.readUTF();
+					String sender = in.readUTF();
+					out.writeUTF("Message");
+					out.writeUTF("CustomError");
+					out.writeUTF(message);
+					out.writeUTF(player);
+					out.writeUTF(sender);
+					if(!source.getServer(server).isEmpty()) {
+						source.sendPluginMessage(server, outstream.toByteArray());
+					}
+				}
 				if(identifier.equals("Echo")) {
 					String server = in.readUTF();
 					String player = in.readUTF();


### PR DESCRIPTION
There is currently now way to listen to messages within the API. This adds an event that fires when a player sends a message to another player. 

This is similar to [https://github.com/Aust1n46/VentureChat/pull/8](https://github.com/Aust1n46/VentureChat/pull/8) but provides the ability to modify the message or cancel it with a custom cancellation message.

Thanks for your time!