### PR TITLE
Add permission checks for hex colors and magic color code

### DIFF
--- a/src/main/java/mineverse/Aust1n46/chat/command/chat/Me.java
+++ b/src/main/java/mineverse/Aust1n46/chat/command/chat/Me.java
@@ -28,9 +28,9 @@ public class Me extends Command {
 					msg = Format.FormatStringLegacyColor(msg);
 				}
 				if (sender.hasPermission("venturechat.color"))
-					msg = Format.FormatStringColor(msg);
+					msg = Format.FormatStringColor(msg, sender.hasPermission("venturechat.color.hex"));
 				if (sender.hasPermission("venturechat.format"))
-					msg = Format.FormatString(msg);
+					msg = Format.FormatString(msg, sender.hasPermission("venturechat.format.magic"));
 				if (sender instanceof Player) {
 					Player p = (Player) sender;
 					Format.broadcastToServer("* " + p.getDisplayName() + msg);

--- a/src/main/java/mineverse/Aust1n46/chat/command/chat/Party.java
+++ b/src/main/java/mineverse/Aust1n46/chat/command/chat/Party.java
@@ -287,10 +287,10 @@ public class Party extends Command {
 							msg = Format.FormatStringLegacyColor(msg);
 						}
 						if (mcp.getPlayer().hasPermission("venturechat.color")) {
-							msg = Format.FormatStringColor(msg);
+							msg = Format.FormatStringColor(msg, mcp.getPlayer().hasPermission("venturechat.color.hex"));
 						}
 						if (mcp.getPlayer().hasPermission("venturechat.format")) {
-							msg = Format.FormatString(msg);
+							msg = Format.FormatString(msg, mcp.getPlayer().hasPermission("venturechat.format.magic"));
 						}
 						if (plugin.getConfig().getString("partyformat").equalsIgnoreCase("Default")) {
 							partyformat = ChatColor.GREEN + "[" + MineverseChatAPI.getMineverseChatPlayer(mcp.getParty()).getName() + "'s Party] " + mcp.getName() + ":" + msg;

--- a/src/main/java/mineverse/Aust1n46/chat/command/message/Message.java
+++ b/src/main/java/mineverse/Aust1n46/chat/command/message/Message.java
@@ -77,10 +77,10 @@ public class Message extends Command {
 					msg = Format.FormatStringLegacyColor(msg);
 				}
 				if (mcp.getPlayer().hasPermission("venturechat.color")) {
-					msg = Format.FormatStringColor(msg);
+					msg = Format.FormatStringColor(msg, mcp.getPlayer().hasPermission("venturechat.color.hex"));
 				}
 				if (mcp.getPlayer().hasPermission("venturechat.format")) {
-					msg = Format.FormatString(msg);
+					msg = Format.FormatString(msg, mcp.getPlayer().hasPermission("venturechat.format.magic"));
 				}
 
 				send = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatfrom").replaceAll("sender_", "")));
@@ -176,10 +176,10 @@ public class Message extends Command {
 			msg = Format.FormatStringLegacyColor(msg);
 		}
 		if (mcp.getPlayer().hasPermission("venturechat.color")) {
-			msg = Format.FormatStringColor(msg);
+			msg = Format.FormatStringColor(msg, mcp.getPlayer().hasPermission("venturechat.color.hex"));
 		}
 		if (mcp.getPlayer().hasPermission("venturechat.format")) {
-			msg = Format.FormatString(msg);
+			msg = Format.FormatString(msg, mcp.getPlayer().hasPermission("venturechat.format.magic"));
 		}
 
 		String send = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("tellformatfrom").replaceAll("sender_", "")));

--- a/src/main/java/mineverse/Aust1n46/chat/command/message/Reply.java
+++ b/src/main/java/mineverse/Aust1n46/chat/command/message/Reply.java
@@ -66,10 +66,10 @@ public class Reply extends Command {
 						msg = Format.FormatStringLegacyColor(msg);
 					}
 					if (mcp.getPlayer().hasPermission("venturechat.color")) {
-						msg = Format.FormatStringColor(msg);
+						msg = Format.FormatStringColor(msg, mcp.getPlayer().hasPermission("venturechat.color.hex"));
 					}
 					if (mcp.getPlayer().hasPermission("venturechat.format")) {
-						msg = Format.FormatString(msg);
+						msg = Format.FormatString(msg, mcp.getPlayer().hasPermission("venturechat.format.magic"));
 					}
 
 					send = Format
@@ -122,10 +122,10 @@ public class Reply extends Command {
 			msg = Format.FormatStringLegacyColor(msg);
 		}
 		if (mcp.getPlayer().hasPermission("venturechat.color")) {
-			msg = Format.FormatStringColor(msg);
+			msg = Format.FormatStringColor(msg, mcp.getPlayer().hasPermission("venturechat.color.hex"));
 		}
 		if (mcp.getPlayer().hasPermission("venturechat.format")) {
-			msg = Format.FormatString(msg);
+			msg = Format.FormatString(msg, mcp.getPlayer().hasPermission("venturechat.format.magic"));
 		}
 
 		String send = Format.FormatStringAll(PlaceholderAPI.setBracketPlaceholders(mcp.getPlayer(), plugin.getConfig().getString("replyformatfrom").replaceAll("sender_", "")));

--- a/src/main/java/mineverse/Aust1n46/chat/listeners/ChatListener.java
+++ b/src/main/java/mineverse/Aust1n46/chat/listeners/ChatListener.java
@@ -116,10 +116,10 @@ public class ChatListener implements Listener {
 					filtered = Format.FormatStringLegacyColor(filtered);
 				}
 				if(mcp.getPlayer().hasPermission("venturechat.color")) {
-					filtered = Format.FormatStringColor(filtered);
+					filtered = Format.FormatStringColor(filtered, mcp.getPlayer().hasPermission("venturechat.color.hex"));
 				}
 				if(mcp.getPlayer().hasPermission("venturechat.format")) {
-					filtered = Format.FormatString(filtered);
+					filtered = Format.FormatString(filtered, mcp.getPlayer().hasPermission("venturechat.format.magic"));
 				}
 				filtered = " " + filtered;
 				
@@ -168,10 +168,10 @@ public class ChatListener implements Listener {
 							filtered = Format.FormatStringLegacyColor(filtered);
 						}
 						if(mcp.getPlayer().hasPermission("venturechat.color")) {
-							filtered = Format.FormatStringColor(filtered);
+							filtered = Format.FormatStringColor(filtered, mcp.getPlayer().hasPermission("venturechat.color.hex"));
 						}
 						if(mcp.getPlayer().hasPermission("venturechat.format")) {
-							filtered = Format.FormatString(filtered);
+							filtered = Format.FormatString(filtered, mcp.getPlayer().hasPermission("venturechat.format.magic"));
 						}
 						filtered = " " + filtered;
 						if(plugin.getConfig().getString("partyformat").equalsIgnoreCase("Default")) {
@@ -468,10 +468,10 @@ public class ChatListener implements Listener {
 			chat = Format.FormatStringLegacyColor(chat);
 		}
 		if(mcp.getPlayer().hasPermission("venturechat.color")) {
-			chat = Format.FormatStringColor(chat);
+			chat = Format.FormatStringColor(chat, mcp.getPlayer().hasPermission("venturechat.color.hex"));
 		}
 		if(mcp.getPlayer().hasPermission("venturechat.format")) {
-			chat = Format.FormatString(chat);
+			chat = Format.FormatString(chat, mcp.getPlayer().hasPermission("venturechat.format.magic"));
 		}
 		if(!mcp.isQuickChat()) {
 			chat = " " + chat;

--- a/src/main/java/mineverse/Aust1n46/chat/listeners/CommandListener.java
+++ b/src/main/java/mineverse/Aust1n46/chat/listeners/CommandListener.java
@@ -105,10 +105,10 @@ public class CommandListener implements Listener {
 						send = Format.FormatStringLegacyColor(send);
 					}
 					if (mcp.getPlayer().hasPermission("venturechat.color")) {
-						send = Format.FormatStringColor(send);
+						send = Format.FormatStringColor(send, mcp.getPlayer().hasPermission("venturechat.color.hex"));
 					}
 					if (mcp.getPlayer().hasPermission("venturechat.format")) {
-						send = Format.FormatString(send);
+						send = Format.FormatString(send, mcp.getPlayer().hasPermission("venturechat.format.magic"));
 					}
 					if (s.startsWith("Command:")) {
 						mcp.getPlayer().chat(s.substring(9).replace("$", send));

--- a/src/main/java/mineverse/Aust1n46/chat/listeners/SignListener.java
+++ b/src/main/java/mineverse/Aust1n46/chat/listeners/SignListener.java
@@ -23,10 +23,10 @@ public class SignListener implements Listener {
 				line = Format.FormatStringLegacyColor(line);
 			}
 			if(mcp.getPlayer().hasPermission("venturechat.color")) {
-				line = Format.FormatStringColor(line);
+				line = Format.FormatStringColor(line, mcp.getPlayer().hasPermission("venturechat.color.hex"));
 			}
 			if(mcp.getPlayer().hasPermission("venturechat.format")) {
-				line = Format.FormatString(line);
+				line = Format.FormatString(line, mcp.getPlayer().hasPermission("venturechat.format.magic"));
 			}
 			event.setLine(a, line);
 		}

--- a/src/main/java/mineverse/Aust1n46/chat/utilities/Format.java
+++ b/src/main/java/mineverse/Aust1n46/chat/utilities/Format.java
@@ -630,7 +630,7 @@ public class Format {
      * @param string to format.
      * @return {@link String}
      */
-	public static String FormatStringColor(String string) {
+	public static String FormatStringColor(String string, boolean hex) {
 		String allFormated = string;
 		allFormated = LEGACY_CHAT_COLOR_DIGITS_PATTERN.matcher(allFormated).replaceAll("\u00A7$1");
 
@@ -644,7 +644,7 @@ public class Format {
 
 		allFormated = allFormated.replaceAll("%", "\\%");
 
-		allFormated = convertHexColorCodeStringToBukkitColorCodeString(allFormated);
+		if(hex)	allFormated = convertHexColorCodeStringToBukkitColorCodeString(allFormated);
 		return allFormated;
 	}
 
@@ -676,9 +676,9 @@ public class Format {
      * @param string to format.
      * @return {@link String}
      */
-	public static String FormatString(String string) {
+	public static String FormatString(String string, boolean magic) {
 		String allFormated = string;
-		allFormated = allFormated.replaceAll("&[kK]", BUKKIT_COLOR_CODE_PREFIX + "k");
+		if(magic) allFormated = allFormated.replaceAll("&[kK]", BUKKIT_COLOR_CODE_PREFIX + "k");
 		allFormated = allFormated.replaceAll("&[lL]", BUKKIT_COLOR_CODE_PREFIX + "l");
 		allFormated = allFormated.replaceAll("&[mM]", BUKKIT_COLOR_CODE_PREFIX + "m");
 		allFormated = allFormated.replaceAll("&[nN]", BUKKIT_COLOR_CODE_PREFIX + "n");
@@ -697,8 +697,8 @@ public class Format {
      * @return {@link String}
      */
 	public static String FormatStringAll(String string) {
-		String allFormated = Format.FormatString(string);
-		allFormated = Format.FormatStringColor(allFormated);
+		String allFormated = Format.FormatString(string, true);
+		allFormated = Format.FormatStringColor(allFormated, true);
 		return allFormated;
 	}
 


### PR DESCRIPTION
This PR adds a permission check for the following:

- Usage of hex color codes in chat
- Usage of the magic formatting code (&k) in chat