### PR TITLE
Paper velocity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>mineverse.Aust1n46.chat</groupId>
     <artifactId>VentureChat</artifactId>
-    <version>3.4.4</version>
+    <version>3.4.5-SNAPSHOT</version>
     <url>https://bitbucket.org/Aust1n46/venturechat/src/master</url>
     <scm>
         <url>https://bitbucket.org/Aust1n46/venturechat/src/master</url>

--- a/src/main/java/mineverse/Aust1n46/chat/listeners/LoginListener.java
+++ b/src/main/java/mineverse/Aust1n46/chat/listeners/LoginListener.java
@@ -74,7 +74,9 @@ public class LoginListener implements Listener {
 		}
 		
 		try {
-			if(plugin.getServer().spigot().getConfig().getBoolean("settings.bungeecord") || plugin.getServer().spigot().getPaperConfig().getBoolean("settings.velocity-support.enabled")) {
+			if(plugin.getServer().spigot().getConfig().getBoolean("settings.bungeecord") 
+					|| plugin.getServer().spigot().getPaperConfig().getBoolean("settings.velocity-support.enabled") 
+					|| plugin.getServer().spigot().getPaperConfig().getBoolean("proxies.velocity.enabled")) {
 				long delayInTicks = 20L;
 				final MineverseChatPlayer sync = mcp;
 				plugin.getServer().getScheduler().runTaskLaterAsynchronously(plugin, new Runnable() {


### PR DESCRIPTION
Add check for new velocity config setting location in the new paper config structure.  Required for VentureChat to detect if a server is a part of a network and should sync player data.