### PR TITLE
Allow other plugins to hook into VentureChat

### DIFF
--- a/src/main/java/mineverse/Aust1n46/chat/MineverseChat.java
+++ b/src/main/java/mineverse/Aust1n46/chat/MineverseChat.java
@@ -361,6 +361,24 @@ public class MineverseChat extends JavaPlugin implements PluginMessageListener {
 		}
 	}
 
+	public static void sendPluginMessage(String pluginId, String chatChannel, String message) {
+		if(MineverseChatAPI.getOnlineMineverseChatPlayers().size() == 0) {
+			return;
+		}
+		ByteArrayOutputStream byteOutStream = new ByteArrayOutputStream();
+		DataOutputStream out = new DataOutputStream(byteOutStream);
+		try {
+			out.writeUTF(pluginId);
+			out.writeUTF(chatChannel);
+			out.writeUTF(message);
+			sendPluginMessage(byteOutStream);
+			out.close();
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+		}
+	}
+
 	@Override
 	public void onPluginMessageReceived(String channel, Player player, byte[] inputStream) {
 		if(!channel.equals(PLUGIN_MESSAGING_CHANNEL)) {


### PR DESCRIPTION
I'm making a plugin and as far as I could see, the only chat message sending possiblity was for DiscordSRV so I just made an extra simple new function for other plugins. Please tell me if I need to change anything / there is a reason this doesn't already exist