### PR TITLE
Add improved URL regex

### DIFF
--- a/src/main/java/mineverse/Aust1n46/chat/utilities/Format.java
+++ b/src/main/java/mineverse/Aust1n46/chat/utilities/Format.java
@@ -177,8 +177,12 @@ public class Format {
 		String lastCode = DEFAULT_COLOR_CODE;
 		do {
 			Pattern pattern = Pattern.compile(
-					"([a-zA-Z0-9" + BUKKIT_COLOR_CODE_PREFIX + "\\-:/]+\\.[a-zA-Z/0-9" + BUKKIT_COLOR_CODE_PREFIX
-							+ "\\-:_#]+(\\.[a-zA-Z/0-9." + BUKKIT_COLOR_CODE_PREFIX + "\\-:;,#\\?\\+=_]+)?)");
+					"((?:[a-zA-Z" + BUKKIT_COLOR_CODE_PREFIX + "][a-zA-Z+\\-." + BUKKIT_COLOR_CODE_PREFIX
+                    + "]*)://)?(?:([^\\s:@]*)(?::([^\\s@]*))?@)?((?:[a-zA-Z0-9\\-." + BUKKIT_COLOR_CODE_PREFIX
+                    + "]*[a-zA-Z0-9])+\\.[a-zA-Z\\-" + BUKKIT_COLOR_CODE_PREFIX + "]{2,}|(?:["
+                    + BUKKIT_COLOR_CODE_PREFIX + "0-9]{1,3}\\.[" + BUKKIT_COLOR_CODE_PREFIX + "0-9]{1,3}\\.["
+                    + BUKKIT_COLOR_CODE_PREFIX + "0-9]{1,3}\\.[" + BUKKIT_COLOR_CODE_PREFIX + "0-9]{1,3}))(?::(["
+                    + BUKKIT_COLOR_CODE_PREFIX + "0-9]{1,5}))?(/[^\\s?]*)*(?:\\?([^\\s]*))?");
 			Matcher matcher = pattern.matcher(remaining);
 			if (matcher.find()) {
 				indexLink = matcher.start();


### PR DESCRIPTION
The current URL regex matches some strings that are not valid URLs, such as `1.0` and `///.///`, and fails to match some valid URLs. The new regular expression, while not exactly aligned with the URI format defined in [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-3), is much more robust. It also supports Bukkit color codes, unlike the library proposed in #93.

```regex
((?:[a-zA-Z&][a-zA-Z+\\-.&]*)://)?(?:([^\\s:@]*)(?::([^\\s@]*))?@)?((?:[a-zA-Z0-9\\-.&]*[a-zA-Z0-9])+\\.[a-zA-Z\\-&]{2,}|(?:[&0-9]{1,3}\\.[&0-9]{1,3}\\.[&0-9]{1,3}\\.[&0-9]{1,3}))(?::([&0-9]{1,5}))?(/[^\\s?]*)*(?:\\?([^\\s]*))?
```

Sample URL: `https://user:pass@github.com:433/Aust1n46/VentureChat?tab=readme-ov-file`

| Match Group | URI Component | Sample Match |
|-------|---------------|---------|
| `((?:[a-zA-Z&][a-zA-Z+\-.&]*)://)?` | Scheme | `https` |
| `(?:([^\s:@]*)(?::([^\s@]*))?@)?` | Credentials | `user:pass` |
| `((?:[a-zA-Z0-9\-.&]*[a-zA-Z0-9])+\.[a-zA-Z\-&]{2,}\|(?:[&0-9]{1,3}\.[&0-9]{1,3}\.[&0-9]{1,3}\.[&0-9]{1,3}))` | Host | `github.com` |
| `(?::([&0-9]{1,5}))?` | Port | `443` |
| `(/[^\s?]*)*` | Path | `/Aust1n46/VentureChat` |
| `(?:\?([^\s]*))?` | Query | `tab=readme-ov-file` |