### PR TITLE
Fix getSound(), message_sound resolution on 1.21+

### DIFF
--- a/src/main/java/mineverse/Aust1n46/chat/utilities/Format.java
+++ b/src/main/java/mineverse/Aust1n46/chat/utilities/Format.java
@@ -970,16 +970,36 @@ public class Format {
 			}
 		}
 	}
-	
+
 	private static Sound getSound(String soundName) {
-		for (Sound sound : Sound.values()) {
-			if (sound.toString().equalsIgnoreCase(soundName)) {
-				return sound;
-			}
-		}
-		Bukkit.getConsoleSender().sendMessage(Format.FormatStringAll("&8[&eVentureChat&8]&c - Message sound invalid!"));
-		return getDefaultMessageSound();
-	}
+    if (soundName == null || soundName.equalsIgnoreCase("none")) {
+        return null;
+    }
+
+    String raw = soundName.trim();
+
+    // Try modern namespaced sound (needed for 1.21+)
+    NamespacedKey key = NamespacedKey.minecraft(raw.toLowerCase());
+    Sound sound = Registry.SOUNDS.get(key);
+
+    // Fallback to legacy enum name
+    if (sound == null) {
+        try {
+            sound = Sound.valueOf(raw.toUpperCase());
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    // Final fallback to default
+    if (sound == null) {
+        Bukkit.getConsoleSender().sendMessage(
+            Format.FormatStringAll("&8[&eVentureChat&8]&c - Message sound invalid: " + raw)
+        );
+        sound = getDefaultMessageSound();
+    }
+
+    return sound;
+}
 	
 	private static Sound getDefaultMessageSound() {
 		if(VersionHandler.is1_7() || VersionHandler.is1_8()) {
@@ -994,3 +1014,4 @@ public class Format {
 		return message.replaceAll("(\u00A7([a-z0-9]))", "");
 	}
 }
+


### PR DESCRIPTION
Fixed message_sound config with resolving namespaced sounds via Registry.SOUNDS with legacy enum fallback.

Previously only attempted enum resolution, causing all valid new namespaced sounds to be rejected as invalid on 1.21+, both legacy wouldn't exist on this version and new ones wouldn't parse. 

Fallback was always being applied for every input other than "None"